### PR TITLE
fix element still vissible on error page

### DIFF
--- a/runtime/plugin.ts
+++ b/runtime/plugin.ts
@@ -26,5 +26,13 @@ export default defineNuxtPlugin((nuxtApp) => {
                 }
             }, Number(`<%= options.delay %>`))
         })
+
+        // Remove element after fatal error occures
+        nuxtApp.hook('app:error', () => {
+            if (loaderHtmlComponent) {
+                // Remove the loading component after the delay.
+                loaderHtmlComponent.remove()
+            }
+        })
     }
 })

--- a/runtime/plugin.ts
+++ b/runtime/plugin.ts
@@ -34,10 +34,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
         // Remove element after fatal error occures
         nuxtApp.hook('app:error', () => {
-            if (loaderHtmlComponent) {
-                // Remove the loading component.
-                removeHTMLComponent()
-            }
+            // Remove the loading component.
+            removeHTMLComponent()
         })
     }
 })

--- a/runtime/plugin.ts
+++ b/runtime/plugin.ts
@@ -17,21 +17,26 @@ export default defineNuxtPlugin((nuxtApp) => {
             document.body.firstChild,
         )
 
+        function removeHTMLComponent() {
+            if (loaderHtmlComponent) {
+                // Remove the loading component.
+                loaderHtmlComponent.remove()
+            }
+        }
+
         // Register the 'page:finish' hook to perform actions after page loading is complete.
         nuxtApp.hook('page:finish', () => {
             setTimeout(() => {
-                if (loaderHtmlComponent) {
-                    // Remove the loading component after the delay.
-                    loaderHtmlComponent.remove()
-                }
+                // Remove the loading component.
+                removeHTMLComponent()
             }, Number(`<%= options.delay %>`))
         })
 
         // Remove element after fatal error occures
         nuxtApp.hook('app:error', () => {
             if (loaderHtmlComponent) {
-                // Remove the loading component after the delay.
-                loaderHtmlComponent.remove()
+                // Remove the loading component.
+                removeHTMLComponent()
             }
         })
     }


### PR DESCRIPTION
When fatal error occured (i.e. 404) the loading element was still visible.