### PR TITLE
fix: use `lodash.template` directly to compile template

### DIFF
--- a/module.ts
+++ b/module.ts
@@ -35,7 +35,7 @@ export default defineNuxtModule({
             // Add the custom plugin template for the SPA loading screen.
             addPluginTemplate({
                 getContents({ options }) {
-                  const contents = readFileSync(resolve('./runtime/plugin.ts'), 'utf-8')
+                  const contents = fs.readFileSync(resolve('./runtime/plugin.ts'), 'utf-8')
                   return template(contents)({ options })
                 },
                 mode: 'client',

--- a/module.ts
+++ b/module.ts
@@ -1,3 +1,4 @@
+import { template } from 'lodash-es'
 import { defineNuxtModule, addPluginTemplate, createResolver } from '@nuxt/kit'
 import fs from 'fs'
 import path from 'path'
@@ -33,7 +34,10 @@ export default defineNuxtModule({
 
             // Add the custom plugin template for the SPA loading screen.
             addPluginTemplate({
-                src: resolve('./runtime/plugin.ts'),
+                getContents({ options }) {
+                  const contents = readFileSync(resolve('./runtime/plugin.ts'), 'utf-8')
+                  return template(contents)({ options })
+                },
                 mode: 'client',
                 options: {
                     html: loadingTemplateContent,


### PR DESCRIPTION
We are going to be removing support for [compiling templates from disk using `lodash.template`](https://github.com/nuxt/nuxt/issues/25332) in Nuxt v4. This is a PR to move lodash usage directly into the module to avoid breaking it on Nuxt 4.

It would also be possible to avoid using it entirely, which I would _strongly_ recommend, either:
* using a custom function to handle the replacement, such as in https://github.com/nuxt-modules/color-mode/pull/240
* or moving the string interpolation logic directly into `getContents`